### PR TITLE
Update ssd1306_i2c.c

### DIFF
--- a/C/ssd1306_i2c.c
+++ b/C/ssd1306_i2c.c
@@ -394,7 +394,7 @@ char* GetIpAddress(void)
     ifr.ifr_addr.sa_family = AF_INET;
     
     /* I want IP address attached to "eth0" */
-    strncpy(ifr.ifr_name, "wlan0", IFNAMSIZ-1);
+    strncpy(ifr.ifr_name, "eth0", IFNAMSIZ-1);
     
     ioctl(fd, SIOCGIFADDR, &ifr);
     


### PR DESCRIPTION
This is set to wlan0. Changed to eth0 for hard wired connections. IP address was showing up as 0.0.0.0 until changed to eth0.